### PR TITLE
End sentence with a period

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1778,7 +1778,7 @@ sub security_recommendations {
     if (@mysqlstatlist) {
         foreach my $line ( sort @mysqlstatlist ) {
             chomp($line);
-            badprint "User '" . $line . "' does not specify hostname restrictions";
+            badprint "User '" . $line . "' does not specify hostname restrictions.";
         }
         push( @generalrec,
             "Restrict Host for user\@% to user\@SpecificDNSorIp" );


### PR DESCRIPTION
Current output:

```
[!!] User 'a@localhost' has user name as password.
[!!] User 'b@%' does not specify hostname restrictions
```


Fixed example output:

```
[!!] User 'a@localhost' has user name as password.
[!!] User 'b@%' does not specify hostname restrictions.
```